### PR TITLE
fix: split release workflow to run git-cliff on Ubuntu

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,10 @@ on:
       - 'v*'
 
 jobs:
-  release:
-    permissions:
-      contents: write
-    runs-on: macos-latest
-
+  changelog:
+    runs-on: ubuntu-latest
+    outputs:
+      content: ${{ steps.release_notes.outputs.content }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,6 +24,15 @@ jobs:
         env:
           OUTPUT: CHANGES.md
           GITHUB_REPO: ${{ github.repository }}
+
+  release:
+    needs: changelog
+    permissions:
+      contents: write
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -56,7 +64,7 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Ultra GitLab ${{ github.ref_name }}'
-          releaseBody: ${{ steps.release_notes.outputs.content }}
+          releaseBody: ${{ needs.changelog.outputs.content }}
           releaseDraft: true
           prerelease: false
           args: --target aarch64-apple-darwin


### PR DESCRIPTION
The git-cliff-action uses GNU `stat -c %s` internally, which fails on macOS runners with `stat: %s: bad format`. Move changelog generation to a separate Ubuntu job and pass the output to the macOS build job.

https://claude.ai/code/session_01FL5BTXktV8eoUjCKoSBZHm

<!--
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
