### PR TITLE
ci: shard Playwright tests across 4 parallel runners

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1/4, 2/4, 3/4, 4/4]
 
     steps:
       - uses: actions/checkout@v4
@@ -24,11 +28,43 @@ jobs:
         run: bunx playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        run: bun run test:e2e
+        run: bunx playwright test --shard=${{ matrix.shard }}
 
-      - name: Upload Playwright report
+      - name: Upload blob report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
+        with:
+          name: blob-report-${{ strategy.job-index }}
+          path: blob-report/
+          retention-days: 1
+
+  merge-reports:
+    if: ${{ !cancelled() }}
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Merge reports
+        run: bunx playwright merge-reports --reporter=html,github ./all-blob-reports
+
+      - name: Upload merged report
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? [['github'], ['html']] : 'html',
+  workers: process.env.CI ? 4 : undefined,
+  reporter: process.env.CI ? [['github'], ['blob']] : 'html',
   use: {
     baseURL: 'http://localhost:1420',
     trace: 'on-first-retry',


### PR DESCRIPTION
## Summary
- Split Playwright tests into 4 shards running on parallel GitHub Actions runners
- Increase workers from 1 to 4 per shard (~16x theoretical parallelism)
- Add merge-reports job to combine blob reports into a single HTML report artifact

## Test plan
- [ ] Watch the workflow run on this PR to verify all 4 shards execute
- [ ] Verify the merged playwright-report artifact is uploaded correctly
- [ ] Compare total CI time against previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)