### PR TITLE
fix: add prefers-reduced-motion accessibility support (WCAG 2.3.3)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -194,3 +194,15 @@ button:focus {
   background: var(--wave-glow-strong);
   color: var(--text-primary);
 }
+
+/* Accessibility: respect user's reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { MotionConfig } from 'motion/react';
 import { useQueries } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom';
 import { isTauri, tauriListen } from './services/transport';
@@ -381,6 +382,7 @@ function AppContent() {
  */
 function App() {
   return (
+    <MotionConfig reducedMotion="user">
     <ThemeProvider>
       <WorkerPoolContextProvider
         poolOptions={{ workerFactory }}
@@ -395,6 +397,7 @@ function App() {
         </ToastProvider>
       </WorkerPoolContextProvider>
     </ThemeProvider>
+    </MotionConfig>
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes the `react-doctor` error (score: 99/100 → 100/100):

> ✗ Project uses a motion library but has no prefers-reduced-motion handling — required for accessibility (WCAG 2.3.3)

## Changes

### `src/App.tsx`
Wraps the app root with `<MotionConfig reducedMotion="user">` from `motion/react`. This tells the motion library to automatically disable transform and layout animations (including the `layoutId` focus-ring animation in `FileNavigation`) when the user's OS has **Reduce Motion** enabled, while preserving safe animations like `opacity` and `backgroundColor`.

### `src/App.css`
Adds a `@media (prefers-reduced-motion: reduce)` block that suppresses CSS `transition-duration` and `animation-duration` across the entire component tree for any motion not managed by the motion library (e.g. the `transition: all 0.25s` on buttons, `transition: color 0.2s` on links).

## References
- [Motion docs — MotionConfig reducedMotion](https://motion.dev/docs/react-motion-config#reducedmotion)
- [Motion docs — Accessibility guide](https://motion.dev/docs/react-accessibility)
- WCAG 2.3.3 Animation from Interactions

_This PR was generated with [Oz](https://warp.dev/oz)._
