### PR TITLE
Remove non-functional notification bell icon from sidebar

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -87,9 +87,4 @@ test.describe('Navigation & Sidebar', () => {
     await expect(page.locator('.titlebar-drag-region')).toBeAttached();
   });
 
-  test('notifications bell is visible in sidebar', async ({ page }) => {
-    await page.goto('/mrs');
-
-    await expect(page.locator('.app-sidebar-bell')).toBeVisible();
-  });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -308,7 +308,7 @@ function AppContent() {
   return (
     <div className="app">
       {isTauri && <div className="titlebar-drag-region" data-tauri-drag-region />}
-      <AppSidebar updateAvailable={updateChecker.available} hasApprovedMRs={hasApprovedMRs} hasActiveToasts={toasts.length > 0} companionEnabled={companionStatusQuery.data?.enabled ?? false} companionDeviceCount={companionStatusQuery.data?.connectedDevices ?? 0} />
+      <AppSidebar updateAvailable={updateChecker.available} hasApprovedMRs={hasApprovedMRs} companionEnabled={companionStatusQuery.data?.enabled ?? false} companionDeviceCount={companionStatusQuery.data?.connectedDevices ?? 0} />
       <div className="app-content">
         <Routes>
           {/* Redirect root to MR list */}

--- a/src/components/AppSidebar/AppSidebar.css
+++ b/src/components/AppSidebar/AppSidebar.css
@@ -107,28 +107,6 @@
   color: var(--accent-hover);
 }
 
-.app-sidebar-bell {
-  position: relative;
-  width: 40px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--text-tertiary);
-}
-
-.notification-dot {
-  position: absolute;
-  top: 6px;
-  right: 6px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--accent-color, #4a9eff);
-  border: 2px solid var(--bg-secondary);
-  pointer-events: none;
-}
-
 .app-sidebar-companion {
   position: relative;
   width: 40px;
@@ -202,7 +180,6 @@
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.2s ease;
   }
 
-  .app-sidebar-bell,
   .app-sidebar-desktop-only {
     display: none;
   }

--- a/src/components/AppSidebar/AppSidebar.tsx
+++ b/src/components/AppSidebar/AppSidebar.tsx
@@ -12,7 +12,6 @@ import './AppSidebar.css';
 interface AppSidebarProps {
   updateAvailable?: boolean;
   hasApprovedMRs?: boolean;
-  hasActiveToasts?: boolean;
   companionEnabled?: boolean;
   companionDeviceCount?: number;
 }
@@ -52,13 +51,6 @@ const PipelineIcon = () => (
   </svg>
 );
 
-const BellIcon = () => (
-  <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9" />
-    <path d="M13.73 21a2 2 0 01-3.46 0" />
-  </svg>
-);
-
 const SmartphoneIcon = () => (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
     <rect x="5" y="2" width="14" height="20" rx="2" ry="2" />
@@ -82,7 +74,7 @@ const navItems: NavItem[] = [
 
 const isBottomPath = (path: string) => navItems.some(item => item.path === path && item.bottom);
 
-export function AppSidebar({ updateAvailable, hasApprovedMRs, hasActiveToasts, companionEnabled, companionDeviceCount = 0 }: AppSidebarProps) {
+export function AppSidebar({ updateAvailable, hasApprovedMRs, companionEnabled, companionDeviceCount = 0 }: AppSidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const sidebarRef = useRef<HTMLElement>(null);
@@ -203,10 +195,6 @@ export function AppSidebar({ updateAvailable, hasApprovedMRs, hasActiveToasts, c
         ))}
       </div>
       <div className="app-sidebar-bottom">
-        <div className="app-sidebar-bell" title="Notifications">
-          <BellIcon />
-          {hasActiveToasts && <span className="notification-dot" />}
-        </div>
         {companionEnabled && (
           <div
             className="app-sidebar-companion app-sidebar-desktop-only"


### PR DESCRIPTION
The notification bell in the navigation sidebar was not clickable/interactive,
so remove it along with its CSS, BellIcon component, hasActiveToasts prop, and
related e2e test.

https://claude.ai/code/session_01H9QZmePjTFerypJMkqecPC